### PR TITLE
Watch for events on the main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: Continuous integration
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
       - "*"


### PR DESCRIPTION
We switched to using the newer `main` branch instead of `master` for the
development trunk, so this should be reflected in the GitHub Actions
configuration.