### PR TITLE
Add a test for relations to tables with KSUID keys

### DIFF
--- a/activerecord-ksuid.gemspec
+++ b/activerecord-ksuid.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'activerecord', '>= 5.0.0'
-  spec.add_dependency 'ksuid'
+  spec.add_dependency 'ksuid', '>= 0.3.0'
 
   spec.add_development_dependency 'bundler', '>= 1.15'
 end

--- a/lib/active_record/ksuid/binary_type.rb
+++ b/lib/active_record/ksuid/binary_type.rb
@@ -41,6 +41,7 @@ module ActiveRecord
         return unless value
 
         value = value.to_s if value.is_a?(::ActiveRecord::Type::Binary::Data)
+        value = ::KSUID::Utils.byte_string_from_hex(value[2..-1]) if value.start_with?('\x')
         ::KSUID.call(value)
       end
 

--- a/spec/activerecord/ksuid/railtie_spec.rb
+++ b/spec/activerecord/ksuid/railtie_spec.rb
@@ -29,8 +29,18 @@ ActiveRecord::Schema.define do
     t.ksuid :id, primary_key: true
   end
 
-  create_table :event_binaries, force: true do |t|
-    t.ksuid_binary :ksuid, index: true, unique: true
+  create_table :event_binaries, force: true, id: false do |t|
+    t.ksuid_binary :id, primary_key: true
+  end
+
+  create_table :event_correlations, force: true do |t|
+    t.references :from, type: :string, limit: 27, foreign_key: { to_table: :event_primary_keys }
+    t.references :to, type: :string, limit: 27, foreign_key: { to_table: :event_primary_keys }
+  end
+
+  create_table :event_binary_correlations, force: true do |t|
+    t.references :from, type: :binary, limit: 20, foreign_key: { to_table: :event_binaries }
+    t.references :to, type: :binary, limit: 20, foreign_key: { to_table: :event_binaries }
   end
 end
 
@@ -46,7 +56,25 @@ end
 
 # A demonstration of KSUIDs persisted as binaries
 class EventBinary < ActiveRecord::Base
-  include ActiveRecord::KSUID[:ksuid, binary: true]
+  include ActiveRecord::KSUID[:id, binary: true]
+end
+
+# A demonstration of a relation to a string KSUID primary key
+class EventCorrelation < ActiveRecord::Base
+  include ActiveRecord::KSUID[:from_id]
+  include ActiveRecord::KSUID[:to_id]
+
+  belongs_to :from, class_name: 'EventPrimaryKey'
+  belongs_to :to, class_name: 'EventPrimaryKey'
+end
+
+# A demonstration of a relation to a binary KSUID primary key
+class EventBinaryCorrelation < ActiveRecord::Base
+  include ActiveRecord::KSUID[:from_id, binary: true]
+  include ActiveRecord::KSUID[:to_id, binary: true]
+
+  belongs_to :from, class_name: 'EventBinary'
+  belongs_to :to, class_name: 'EventBinary'
 end
 
 RSpec.describe 'ActiveRecord integration' do
@@ -98,13 +126,53 @@ RSpec.describe 'ActiveRecord integration' do
     it 'generates a KSUID upon initialization' do
       event = EventBinary.new
 
-      expect(event.ksuid).to be_a(::KSUID::Type)
+      expect(event.id).to be_a(::KSUID::Type)
     end
 
     it 'persists the KSUID to the database' do
       event = EventBinary.create
 
-      expect(event.ksuid).to be_a(::KSUID::Type)
+      expect(event.id).to be_a(::KSUID::Type)
+    end
+  end
+
+  context 'with a reference to string KSUID-keyed tables' do
+    after do
+      EventCorrelation.delete_all
+      EventPrimaryKey.delete_all
+    end
+
+    it 'can relate to the other model' do
+      event1 = EventPrimaryKey.create!
+      event2 = EventPrimaryKey.create!
+      correlation = EventCorrelation.create!(from: event1, to: event2)
+
+      correlation.reload
+
+      aggregate_failures do
+        expect(correlation.from).to eq event1
+        expect(correlation.to).to eq event2
+      end
+    end
+  end
+
+  context 'with a reference to binary KSUID-keyed tables' do
+    after do
+      EventBinaryCorrelation.delete_all
+      EventBinary.delete_all
+    end
+
+    it 'can relate to the other model' do
+      event1 = EventBinary.create!
+      event2 = EventBinary.create!
+      correlation = EventBinaryCorrelation.create!(from: event1, to: event2)
+
+      correlation.reload
+
+      aggregate_failures do
+        expect(correlation.from).to eq event1
+        expect(correlation.to).to eq event2
+      end
     end
   end
 end


### PR DESCRIPTION
In order to ensure that relations with KSUID keys work, we need a test to make sure they do.

In this case, the binary representation was buggy by default and required bumping the required base gem to the new version.