### PR TITLE
Set up the framework for adding more databases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,5 +56,5 @@ jobs:
           bundle config path vendor/bundle
           bundle install --jobs 4 --retry 3
           ./cc-test-reporter before-build
-          bundle exec rake spec yard:doctest
+          bundle exec rake db:reset spec:all yard:doctest
           ./cc-test-reporter after-build --exit-code $?

--- a/spec/activerecord/ksuid/railtie_spec.rb
+++ b/spec/activerecord/ksuid/railtie_spec.rb
@@ -7,7 +7,12 @@ require 'logger'
 require 'activerecord/ksuid'
 require 'active_record/ksuid/railtie'
 
-ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
+ActiveRecord::Base.establish_connection(
+  adapter: ENV.fetch('DRIVER'),
+  host: ENV['DB_HOST'],
+  username: ENV['DB_USERNAME'],
+  database: ENV.fetch('DATABASE', 'activerecord-ksuid_test')
+)
 ActiveRecord::Base.logger = Logger.new(IO::NULL)
 ActiveRecord::Schema.verbose = false
 


### PR DESCRIPTION
We currently only test against SQLite, but that's a small subset of actual usage in Rails. To ensure the gem works against common databases, we need to test against them. This change introduces the framework in which we will be able to add more databases for testing purposes.