### PR TITLE
Add testing for PostgreSQL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,19 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_HOST_AUTH_METHOD: trust
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
     strategy:
       matrix:
         ruby:
@@ -34,6 +47,10 @@ jobs:
           - ruby: "jruby-9.2.13.0"
             rails: "6.1"
     name: Test Ruby ${{ matrix.ruby }} and Rails ${{ matrix.rails }}
+    env:
+      CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+      DB_HOST: 127.0.0.1
+      PGHOST: 127.0.0.1
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
@@ -48,7 +65,6 @@ jobs:
       - name: Run test suite
         env:
           BUNDLE_GEMFILE: gemfiles/rails_${{ matrix.rails }}.gemfile
-          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
         run: |
           curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
           chmod +x ./cc-test-reporter

--- a/Appraisals
+++ b/Appraisals
@@ -2,32 +2,41 @@
 
 if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.7.0')
   appraise 'rails-5.0' do
+    gem 'activerecord-jdbcpostgresql-adapter', '~> 50', platforms: %i[jruby]
     gem 'activerecord-jdbcsqlite3-adapter', '~> 50', platforms: %i[jruby]
+    gem 'pg', '~> 0.18', platforms: %i[mri mingw x64_mingw]
     gem 'rails', '~> 5.0.0'
     gem 'sqlite3', '~> 1.3.6', platforms: %i[mri mingw x64_mingw]
   end
 
   appraise 'rails-5.1' do
+    gem 'activerecord-jdbcpostgresql-adapter', '~> 51', platforms: %i[jruby]
     gem 'activerecord-jdbcsqlite3-adapter', '~> 51', platforms: %i[jruby]
+    gem 'pg', '~> 0.18', platforms: %i[mri mingw x64_mingw]
     gem 'rails', '~> 5.1.0'
     gem 'sqlite3', '~> 1.3', '>= 1.3.6', platforms: %i[mri mingw x64_mingw]
   end
 
   appraise 'rails-5.2' do
+    gem 'activerecord-jdbcpostgresql-adapter', '~> 52', platforms: %i[jruby]
     gem 'activerecord-jdbcsqlite3-adapter', '~> 52', platforms: %i[jruby]
+    gem 'pg', '>= 0.18', '< 2.0', platforms: %i[mri mingw x64_mingw]
     gem 'rails', '~> 5.2.0'
     gem 'sqlite3', '~> 1.3', '>= 1.3.6', platforms: %i[mri mingw x64_mingw]
   end
 end
 
 appraise 'rails-6.0' do
+  gem 'activerecord-jdbcpostgresql-adapter', '~> 60', platforms: %i[jruby]
   gem 'activerecord-jdbcsqlite3-adapter', '~> 60', platforms: %i[jruby]
+  gem 'pg', '>= 0.18', '< 2.0', platforms: %i[mri mingw x64_mingw]
   gem 'rails', '~> 6.0.0'
   gem 'sqlite3', '~> 1.4', platforms: %i[mri mingw x64_mingw]
 end
 
 unless RUBY_ENGINE == 'jruby'
   appraise 'rails-6.1' do
+    gem 'pg', '~> 1.1', platforms: %i[mri mingw x64_mingw]
     gem 'rails', '~> 6.1.0.rc1'
     gem 'sqlite3', '~> 1.4', platforms: %i[mri mingw x64_mingw]
   end

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,14 +27,15 @@ Ideally, a bug report should include a pull request with failing specs.
 1. [Fork the repository](https://docs.github.com/en/free-pro-team@latest/github/getting-started-with-github/fork-a-repo).
 2. [Create a topic branch](https://help.github.com/articles/creating-and-deleting-branches-within-your-repository/).
 3. Add specs for your unimplemented feature or bug fix.
-4. Run `appraisal rspec`. If your specs pass, return to step 3.
-5. Implement your feature or bug fix.
-6. Run `appraisal rspec` to check that your specs pass. If they don't, return to step 5.
-7. Run `bundle exec rake`. If any of the linters fail, return to step 5.
-8. Open `coverage/index.html`. If your changes are not completely covered by your tests, return to step 3.
-9. Add documentation for your feature or bug fix.
-10. Commit and push your changes.
-11. [Submit a pull request](https://help.github.com/articles/creating-a-pull-request/).
+4. Run `bundle exec rake db:reset` to create any necessary test databases. This requires PostgreSQL.
+5. Run `appraisal rspec`. If your specs pass, return to step 3.
+6. Implement your feature or bug fix.
+7. Run `appraisal rspec` to check that your specs pass. If they don't, return to step 5.
+8. Run `bundle exec rake`. If any of the linters fail, return to step 5.
+9. Open `coverage/index.html`. If your changes are not completely covered by your tests, return to step 3.
+10. Add documentation for your feature or bug fix.
+11. Commit and push your changes.
+12. [Submit a pull request](https://help.github.com/articles/creating-a-pull-request/).
 
 ## Tools to Help You Succeed
 

--- a/gemfiles/rails_5.0.gemfile
+++ b/gemfiles/rails_5.0.gemfile
@@ -2,7 +2,9 @@
 
 source "https://rubygems.org"
 
+gem "activerecord-jdbcpostgresql-adapter", "~> 50", platforms: [:jruby]
 gem "activerecord-jdbcsqlite3-adapter", "~> 50", platforms: [:jruby]
+gem "pg", "~> 0.18", platforms: [:mri, :mingw, :x64_mingw]
 gem "rails", "~> 5.0.0"
 gem "sqlite3", "~> 1.3.6", platforms: [:mri, :mingw, :x64_mingw]
 

--- a/gemfiles/rails_5.1.gemfile
+++ b/gemfiles/rails_5.1.gemfile
@@ -2,7 +2,9 @@
 
 source "https://rubygems.org"
 
+gem "activerecord-jdbcpostgresql-adapter", "~> 51", platforms: [:jruby]
 gem "activerecord-jdbcsqlite3-adapter", "~> 51", platforms: [:jruby]
+gem "pg", "~> 0.18", platforms: [:mri, :mingw, :x64_mingw]
 gem "rails", "~> 5.1.0"
 gem "sqlite3", "~> 1.3", ">= 1.3.6", platforms: [:mri, :mingw, :x64_mingw]
 

--- a/gemfiles/rails_5.2.gemfile
+++ b/gemfiles/rails_5.2.gemfile
@@ -2,7 +2,9 @@
 
 source "https://rubygems.org"
 
+gem "activerecord-jdbcpostgresql-adapter", "~> 52", platforms: [:jruby]
 gem "activerecord-jdbcsqlite3-adapter", "~> 52", platforms: [:jruby]
+gem "pg", ">= 0.18", "< 2.0", platforms: [:mri, :mingw, :x64_mingw]
 gem "rails", "~> 5.2.0"
 gem "sqlite3", "~> 1.3", ">= 1.3.6", platforms: [:mri, :mingw, :x64_mingw]
 

--- a/gemfiles/rails_6.0.gemfile
+++ b/gemfiles/rails_6.0.gemfile
@@ -2,7 +2,9 @@
 
 source "https://rubygems.org"
 
+gem "activerecord-jdbcpostgresql-adapter", "~> 60", platforms: [:jruby]
 gem "activerecord-jdbcsqlite3-adapter", "~> 60", platforms: [:jruby]
+gem "pg", ">= 0.18", "< 2.0", platforms: [:mri, :mingw, :x64_mingw]
 gem "rails", "~> 6.0.0"
 gem "sqlite3", "~> 1.4", platforms: [:mri, :mingw, :x64_mingw]
 

--- a/gemfiles/rails_6.1.gemfile
+++ b/gemfiles/rails_6.1.gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "pg", "~> 1.1", platforms: [:mri, :mingw, :x64_mingw]
 gem "rails", "~> 6.1.0.rc1"
 gem "sqlite3", "~> 1.4", platforms: [:mri, :mingw, :x64_mingw]
 

--- a/lib/active_record/ksuid/binary_type.rb
+++ b/lib/active_record/ksuid/binary_type.rb
@@ -59,7 +59,7 @@ module ActiveRecord
       # @api private
       # @return [Symbol]
       def type
-        :ksuid_binary
+        :binary
       end
     end
   end

--- a/lib/active_record/ksuid/type.rb
+++ b/lib/active_record/ksuid/type.rb
@@ -58,7 +58,7 @@ module ActiveRecord
       # @api private
       # @return [Symbol]
       def type
-        :ksuid
+        :string
       end
     end
   end


### PR DESCRIPTION
To ensure that the gem works for PostgreSQL, we need to test against it. This change ensures that we do.

Also, fix a bug when using the gem in databases other than SQLite.

Relates to #5 