### PR TITLE
Add the familiar spec task to Rake

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -59,6 +59,8 @@ namespace :db do
   end
 end
 
+task spec: %i[spec:all]
+
 if ENV['APPRAISAL_INITIALIZED']
   require 'rspec/core/rake_task'
 


### PR DESCRIPTION
Instead of requiring the `spec:all` group, this effectively aliases spec
to it.